### PR TITLE
Feature/asset loader

### DIFF
--- a/src/minicosm/core.cljs
+++ b/src/minicosm/core.cljs
@@ -26,7 +26,7 @@
          on-error (fn [] (swap! counts update :error inc))
          to-images (into {} (map (fn [[k v]] [k (url-to-img v on-load on-error)]) assets))]
      (draw-loading ctx)
-     (js/requestAnimationFrame (fn [] (asset-loader ctx to-images counts)))))
+     (js/requestAnimationFrame (fn [_] (asset-loader ctx to-images counts)))))
   ([ctx assets counts]
    (let [{:keys [loaded error total]} @counts]
      (if (= (+ loaded error)
@@ -34,7 +34,7 @@
        assets
        (do 
          (draw-loading ctx)
-         (js/requestAnimationFrame (fn [] (asset-loader ctx assets counts))))))))
+         (js/requestAnimationFrame (fn [_] (asset-loader ctx assets counts))))))))
 
 (defn- game-loop! [t ctx key-evs state assets {:keys [on-key on-tick to-draw] :as handlers}]
   (let [new-state (-> state

--- a/src/minicosm/demo.cljs
+++ b/src/minicosm/demo.cljs
@@ -30,9 +30,10 @@
     (for [x (range 32)]
       (make-stars))))
 
-(defn draw [[x y]]
+(defn draw [[x y] assets]
   [:canvas {}
-   [:map {:pos [0 0] :dim [32 24] :size 16} tilemap]
+   [:image {:pos [0 0]} (:space assets)]
+   #_ [:map {:pos [0 0] :dim [32 24] :size 16} tilemap]
    [:sprite {:pos [x y]} sprite]
    [:text {:pos [32 32] :color "white" :font "16px serif"} "THIS IS A TEST"]
    [:group {:desc "lines"}
@@ -43,6 +44,7 @@
 
 (def game-handlers
   {:init (fn [] [128 128])
+   :assets (fn [] {:space "https://images.pexels.com/photos/957010/milky-way-starry-sky-night-sky-star-957010.jpeg"})
    :on-key (fn [[x y] key-evs]
              (cond
                (key-evs "ArrowUp") [x (- y 3)]


### PR DESCRIPTION
Adds a new key function and API for loading assets from URLs with proper loading confirmation before to start the game.

At present, this doesn't work, for two reasons:
- loading never terminates because the atom containing the load counts never updates. The callback *is* called, because the log message triggers, but the call to `swap!` doesn't seem to happen at all.
- the asset-loader function for some reason returns the integer request id from `requestAnimationFrame` instead of returning the asset map

Posting this as WIP 'cause I could use some eyes on.