### PR TITLE
Apply Transforms to all DDN Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ DDN defines a number of common elements, described as follows, with their option
     - `:pivot` (optional) - a point, **relative to `:pos`**, around which the image will be rotated. Defaults to `[0 0]`.
     - `:view` (optional) - Defines a sub-rectangle of the image to be drawn, in the form of a pair of pairs of coordinates (ie. `[[x1 y1] [x2 y2]]). If not provided, the whole image is displayed (limited by the size of the canvas)
 * `:map` - A tilemap to be drawn. The contents of the element should be a 2D array of sprites. Options:
+
+    - `:dim` - the dimensions of the tile map in tiles, as a pair of width and height: `[w h]`.
+    - `:size` - the dimensions of each tile in pixels, as an integer. Tiles are assumed to be square. 
+    - `:view` (optional) - Defines a sub-section of the map to be drawn, as a pair of pairs of x/y coordinates (ie. `[[x1 y1] [x2 y2]]). Note that this is by pixel, not tile, to allow for smooth scrolling of partial tiles. If not provided the whole map is drawn.
     - `:pos` (optional) - the coordinates at which to begin drawing the map, as a pair (ie. `[x y]`). If not provided assumes `[0 0]`.
     - `:scale` (optional) - a number by which the map will be uniformly scaled. Defaults to `1`.
     - `:rotate` (optional) - in radians, the extent of rotation of the entire map (_not_ tiles individually) clockwise around `:pivot`. Defaults to `0`.
     - `:pivot` (optional) - a point, **relative to `:pos`**, around which the map will be rotated. Defaults to `[0 0]`.
-    - `:dim` - the dimensions of the tile map in tiles, as a pair of width and height: `[w h]`.
-    - `:size` - the dimensions of each tile in pixels, as an integer. Tiles are assumed to be square.
-    - `:view` (optional) - Defines a sub-section of the map to be drawn, as a pair of pairs of x/y coordinates (ie. `[[x1 y1] [x2 y2]]). Note that this is by pixel, not tile, to allow for smooth scrolling of partial tiles. If not provided the whole map is drawn.
 * `:sprite` - A sprite to be drawn. Contents should contain an image value. Options:
     - `:pos` - A pair of coordinates at which to draw the sprite (ie. `[x y]`).
     - `:scale` (optional) - a number by which the sprite will be uniformly scaled. Defaults to `1`.
@@ -90,27 +91,27 @@ DDN defines a number of common elements, described as follows, with their option
     - `:pivot` (optional) - a point, **relative to `:pos`**, around which the sprite will be rotated. Defaults to `[0 0]`.
 * `:text` - Indicates text to be drawn. Contents should be a string or series of strings. Options:
     - `:pos` - a pair indicating the x/y coordinates at which to begin drawing the text.
+    - `:color`: a string containing the CSS color value of the text.
+    - `:font`: a string containing the CSS font value for the text.
     - `:scale` (optional) - a number by which the text will be uniformly scaled. Defaults to `1`.
     - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
     - `:pivot` (optional) - a point, **relative to `:pos`**, around which the text will be rotated. Defaults to `[0 0]`.
-    - `:color`: a string containing the CSS color value of the text.
-    - `:font`: a string containing the CSS font value for the text.
 * `:rect` - A rectangle to be drawn on screen. Options:
     - `:pos` - a pair indicating the x/y coordinates of the origin point of the rectangle
-    - `:scale` (optional) - a number by which the rect will be uniformly scaled. Defaults to `1`.
-    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
-    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the rect will be rotated. Defaults to `[0 0]`.
     - `:dim` - a pair indicating the width and height (`[w h]`) of the rect
     - `:style` - One of either `:stroke` (line only) or `:fill` (filled rect)
     - `:color` - A CSS color value for the color of the rect
+    - `:scale` (optional) - a number by which the rect will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the rect will be rotated. Defaults to `[0 0]`.
 * `:circ` - A circle or ellipse. Options:
     - `:pos` - a pair indicating the x/y coords of the center of the circ
-    - `:scale` (optional) - a number by which the circ will be uniformly scaled. Defaults to `1`.
-    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
-    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the circ will be rotated. Defaults to `[0 0]`.
     - `:r` - A pair indicating the major/minor (horizontal/vertical) radius of the circ
     - `:style` - One of either `:stroke` (line only) or `:fill` (filled circ)
     - `:color` - A CSS color value for the color of the circ
+    - `:scale` (optional) - a number by which the circ will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the circ will be rotated. Defaults to `[0 0]`.
 * `:line` - A line to be drawn. Options:
     - `:from` - a pair of x/y coordinates for the origin of the line
     - `:to` - a pair of x/y coords for the endpoint of the line

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ DDN defines a number of common elements, described as follows, with their option
 
 * `:group` - A grouping of multiple elements to be drawn. This is useful both as the base element for an entire drawing, or for providing a single value that contains multiple elements to be drawn. The body should contain *either* 1 or more child elements which will be drawn sequentially to the canvas, *or* a list containing 1 or more child elements. `:group` will ignore any `nil?` elements in the body; this is to allow safe use of conditional contents. Options:
     - `:desc` (optional) - a string describing the nature of the group. useful for documentation purposes.
+    - `:rotate`
 * `:image` - A static image to be drawn. The contents of the element should be an image value. Options:
     - `:pos` (optional) - the coordinates at which to place the image, as a pair of coordinates (ie. `[x y]`). If not provided, assumes `[0 0]` coordinates.
     - `:view` (optional) - Defines a sub-rectangle of the image to be drawn, in the form of a pair of pairs of coordinates (ie. `[[x1 y1] [x2 y2]]). If not provided, the whole image is displayed (limited by the size of the canvas)

--- a/README.md
+++ b/README.md
@@ -65,28 +65,49 @@ DDN defines a number of common elements, described as follows, with their option
 
 * `:group` - A grouping of multiple elements to be drawn. This is useful both as the base element for an entire drawing, or for providing a single value that contains multiple elements to be drawn. The body should contain *either* 1 or more child elements which will be drawn sequentially to the canvas, *or* a list containing 1 or more child elements. `:group` will ignore any `nil?` elements in the body; this is to allow safe use of conditional contents. Options:
     - `:desc` (optional) - a string describing the nature of the group. useful for documentation purposes.
-    - `:rotate`
+    - `:pos` (optional) - the coordinates at which to begin drawing the group, as a pair (ie. `[x y]`). If not provided assumes `[0 0]`. **When provided, the `:pos` of all children will be _relative_ to this point.**
+    - `:scale` (optional) - a number by which the group will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - In radians, the extent of rotation of the entire group (_not_ children individually) clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the group will be rotated. Defaults to `[0 0]`.
 * `:image` - A static image to be drawn. The contents of the element should be an image value. Options:
     - `:pos` (optional) - the coordinates at which to place the image, as a pair of coordinates (ie. `[x y]`). If not provided, assumes `[0 0]` coordinates.
+    - `:scale` (optional) - a number by which the image will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the image will be rotated. Defaults to `[0 0]`.
     - `:view` (optional) - Defines a sub-rectangle of the image to be drawn, in the form of a pair of pairs of coordinates (ie. `[[x1 y1] [x2 y2]]). If not provided, the whole image is displayed (limited by the size of the canvas)
 * `:map` - A tilemap to be drawn. The contents of the element should be a 2D array of sprites. Options:
     - `:pos` (optional) - the coordinates at which to begin drawing the map, as a pair (ie. `[x y]`). If not provided assumes `[0 0]`.
+    - `:scale` (optional) - a number by which the map will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation of the entire map (_not_ tiles individually) clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the map will be rotated. Defaults to `[0 0]`.
     - `:dim` - the dimensions of the tile map in tiles, as a pair of width and height: `[w h]`.
     - `:size` - the dimensions of each tile in pixels, as an integer. Tiles are assumed to be square.
     - `:view` (optional) - Defines a sub-section of the map to be drawn, as a pair of pairs of x/y coordinates (ie. `[[x1 y1] [x2 y2]]). Note that this is by pixel, not tile, to allow for smooth scrolling of partial tiles. If not provided the whole map is drawn.
 * `:sprite` - A sprite to be drawn. Contents should contain an image value. Options:
     - `:pos` - A pair of coordinates at which to draw the sprite (ie. `[x y]`).
+    - `:scale` (optional) - a number by which the sprite will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the sprite will be rotated. Defaults to `[0 0]`.
 * `:text` - Indicates text to be drawn. Contents should be a string or series of strings. Options:
     - `:pos` - a pair indicating the x/y coordinates at which to begin drawing the text.
+    - `:scale` (optional) - a number by which the text will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the text will be rotated. Defaults to `[0 0]`.
     - `:color`: a string containing the CSS color value of the text.
     - `:font`: a string containing the CSS font value for the text.
 * `:rect` - A rectangle to be drawn on screen. Options:
     - `:pos` - a pair indicating the x/y coordinates of the origin point of the rectangle
+    - `:scale` (optional) - a number by which the rect will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the rect will be rotated. Defaults to `[0 0]`.
     - `:dim` - a pair indicating the width and height (`[w h]`) of the rect
     - `:style` - One of either `:stroke` (line only) or `:fill` (filled rect)
     - `:color` - A CSS color value for the color of the rect
 * `:circ` - A circle or ellipse. Options:
     - `:pos` - a pair indicating the x/y coords of the center of the circ
+    - `:scale` (optional) - a number by which the circ will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the circ will be rotated. Defaults to `[0 0]`.
     - `:r` - A pair indicating the major/minor (horizontal/vertical) radius of the circ
     - `:style` - One of either `:stroke` (line only) or `:fill` (filled circ)
     - `:color` - A CSS color value for the color of the circ
@@ -95,13 +116,22 @@ DDN defines a number of common elements, described as follows, with their option
     - `:to` - a pair of x/y coords for the endpoint of the line
     - `:width` - the width of the line in pixels
     - `:color` - a CSS color value for the color of the line
+    - `:pos` (optional) - if provided, makes `:from` and `:to` **relative** to the provided point, rather than to the global canvas. Defaults to `[0 0]`.
+    - `:scale` (optional) - a number by which the line will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the line will be rotated. Defaults to `[0 0]`.
 * `:point` - A single pixel point. 
     - `:pos` - A pair of x/y coordinates (eg. `[45 12]`).
     - `:color` - A string containing a CSS color value.
+    
 * `:path` - A path defining a shape drawn with arbitrary lines. The body should be a vector of x/y pairs, starting from the origin point, and ending with the final point of the shape. 
     - `:width` - the width in pixels of the lines
     - `:color` - the CSS color value for the line/fill of the shape
     - `:style` - one of `:stroke`/`:fill`
+    - `:pos` (optional) - if provided, makes the coordinates provided in the body **relative** to the provided point, rather than to the global canvas. Defaults to `[0 0]`.
+    - `:scale` (optional) - a number by which the path will be uniformly scaled. Defaults to `1`.
+    - `:rotate` (optional) - in radians, the extent of rotation clockwise around `:pivot`. Defaults to `0`.
+    - `:pivot` (optional) - a point, **relative to `:pos`**, around which the path will be rotated. Defaults to `[0 0]`.
 
 ## Development
 


### PR DESCRIPTION
I just want to say I'm really excited about this project. I love the architectural simplicity! I thought I would make a suggestion for #3 and #4, although it doesn't follow your line of thought. I created a new function, `render-with-transforms!`, that every DDN primitive (i.e. everything but `:group`) calls when it does its final draw step. It passes this draw step as a lambda to the `render-with-transforms!`, which then inspects the DDN's attributes for `:pos` for translation, `:rotate` and `:pivot` for rotating around some point, and `:scale`. It provides defaults for each of these such that the API doesn't break - `demo.cljs` hasn't been changed and the output seems identical. However, any of these primitives can now be scaled, rotated around a pivot, or translated, without duplicated code.

There are some small surprises:
- `:path` and `:line` don't have a `:pos` normally. A `:path` or a `:line` without a `:pos` can use "world" coordinates for their points, but if given a `:pos` their points must be in a "local" coordinates (relative to the `:pos`). This is perhaps a feature.
- Likewise, rotating `:path` and `:line` elements without a `:pos` can lead to possibly unintended behavior. A `:pivot` is normally in local coordinates for whatever element it is rotating, but for global `:path` and `:line` elements, no local space is defined (or rather, local space is identical to global space). Therefore, a `:pivot` with no `:pos` is unexpectedly in global space for those two elements.

I tested this with every element type in `demo.cljs` but with no others.

Please feel free to nitpick any style or architecture issues you may have.